### PR TITLE
Store all the categories the product is part of

### DIFF
--- a/src/importer/products.js
+++ b/src/importer/products.js
@@ -39,7 +39,6 @@ const importer = ({ config, elasticClient, apiConnector, logger, page = 1, perPa
       let body = chunk.toJSON().body
       let products = JSON.parse(body)
       if (!Array.isArray(products) || products.length===0) {
-        console.log(products)
         logger.info(`There are no products on page ${page}`)
         return;
       }


### PR DESCRIPTION
When you visit a category page it does not show products that have as category a sub category of it. So we need to store also in the product the parent categories.